### PR TITLE
fix(avm2): Parse keys of metadata info items first before assigning values

### DIFF
--- a/Flazzy/ABC/ASItemInfo.cs
+++ b/Flazzy/ABC/ASItemInfo.cs
@@ -1,32 +1,22 @@
-﻿using Flazzy.IO;
+﻿namespace Flazzy.ABC;
 
-namespace Flazzy.ABC
+public sealed class ASItemInfo
 {
-    public class ASItemInfo : FlashItem
+    private readonly ABCFile _abc;
+
+    public int KeyIndex { get; set; }
+    public string Key => _abc.Pool.Strings[KeyIndex];
+
+    public int ValueIndex { get; set; }
+    public string Value => _abc.Pool.Strings[ValueIndex];
+
+    public ASItemInfo(ABCFile abc, int keyIndex, int valueIndex)
     {
-        private readonly ABCFile _abc;
+        _abc = abc;
 
-        public int KeyIndex { get; set; }
-        public string Key => _abc.Pool.Strings[KeyIndex];
-
-        public int ValueIndex { get; set; }
-        public string Value => _abc.Pool.Strings[ValueIndex];
-
-        public ASItemInfo(ABCFile abc)
-        {
-            _abc = abc;
-        }
-        public ASItemInfo(ABCFile abc, FlashReader input)
-            : this(abc)
-        {
-            KeyIndex = input.ReadInt30();
-            ValueIndex = input.ReadInt30();
-        }
-
-        public override void WriteTo(FlashWriter output)
-        {
-            output.WriteInt30(KeyIndex);
-            output.WriteInt30(ValueIndex);
-        }
+        KeyIndex = keyIndex;
+        ValueIndex = valueIndex;
     }
+
+    public override string ToString() => $"{Key}=\"{Value}\"";
 }

--- a/Flazzy/ABC/ASMetadata.cs
+++ b/Flazzy/ABC/ASMetadata.cs
@@ -1,43 +1,52 @@
 ﻿using Flazzy.IO;
 
-namespace Flazzy.ABC
+namespace Flazzy.ABC;
+
+public sealed class ASMetadata : FlashItem
 {
-    public class ASMetadata : FlashItem
+    private readonly ABCFile _abc;
+
+    public int NameIndex { get; set; }
+    public string Name => _abc.Pool.Strings[NameIndex];
+
+    public List<ASItemInfo> Items { get; }
+
+    public ASMetadata(ABCFile abc)
     {
-        private readonly ABCFile _abc;
+        _abc = abc;
 
-        public int NameIndex { get; set; }
-        public string Name => _abc.Pool.Strings[NameIndex];
-
-        public List<ASItemInfo> Items { get; }
-
-        public ASMetadata(ABCFile abc)
+        Items = new List<ASItemInfo>();
+    }
+    public ASMetadata(ABCFile abc, FlashReader input)
+        : this(abc)
+    {
+        NameIndex = input.ReadInt30();
+        Items.Capacity = input.ReadInt30();
+        if (Items.Capacity > 0)
         {
-            _abc = abc;
-
-            Items = new List<ASItemInfo>();
-        }
-        public ASMetadata(ABCFile abc, FlashReader input)
-            : this(abc)
-        {
-            NameIndex = input.ReadInt30();
-            Items.Capacity = input.ReadInt30();
+            Span<int> keys = stackalloc int[Items.Capacity];
             for (int i = 0; i < Items.Capacity; i++)
             {
-                var itemInfo = new ASItemInfo(abc, input);
-                Items.Add(itemInfo);
+                keys[i] = input.ReadInt30();
+            }
+            for (int i = 0; i < keys.Length; i++)
+            {
+                Items.Add(new ASItemInfo(abc, keys[i], input.ReadInt30()));
             }
         }
+    }
 
-        public override void WriteTo(FlashWriter output)
+    public override void WriteTo(FlashWriter output)
+    {
+        output.WriteInt30(NameIndex);
+        output.WriteInt30(Items.Count);
+        for (int i = 0; i < Items.Count; i++)
         {
-            output.WriteInt30(NameIndex);
-            output.WriteInt30(Items.Count);
-            for (int i = 0; i < Items.Count; i++)
-            {
-                ASItemInfo item = Items[i];
-                item.WriteTo(output);
-            }
+            output.WriteInt30(Items[i].KeyIndex);
+        }
+        for (int i = 0; i < Items.Count; i++)
+        {
+            output.WriteInt30(Items[i].ValueIndex);
         }
     }
 }


### PR DESCRIPTION
Apply sealed modifier to ASMetadata.
Apply sealed modifier to ASItemInfo
Remove FlashItem base class from ASItemInfo
Remove WriteTo override method
Remove (ABCFile, FlashReader) constructor
Add (ABCFile, int, int) constructor for adding a key/value pair